### PR TITLE
Returns false if code is nil

### DIFF
--- a/lib/brval/cnpj.rb
+++ b/lib/brval/cnpj.rb
@@ -1,9 +1,8 @@
 module Brval
   class Cnpj < Val
 
-    def mask
-      code_mask = super
-      code_mask.insert(2, '.').insert(6, '.').insert(10, '/').insert(15, '-')
+    def masked
+      @code.dup.insert(2, '.').insert(6, '.').insert(10, '/').insert(15, '-')
     end
 
     private

--- a/lib/brval/cpf.rb
+++ b/lib/brval/cpf.rb
@@ -1,9 +1,8 @@
 module Brval
   class Cpf < Val
 
-    def mask
-      code_mask = super
-      code_mask.insert(3, '.').insert(7, '.').insert(11, '-')
+    def masked
+      @code.dup.insert(3, '.').insert(7, '.').insert(11, '-')
     end
 
     private

--- a/lib/brval/val.rb
+++ b/lib/brval/val.rb
@@ -4,15 +4,17 @@ module Brval
     attr_accessor :code
 
     def initialize(code)
-      raise ArgumentError, 'The br code informed is nil' if code.nil?
+      return if code.nil?
       @code = code.tr('^0-9', '')
     end
 
     def mask
+      return if @code.nil?
       code_mask = @code.dup
     end
 
     def valid?
+      return false if @code.nil?
       validate_code
     end
 

--- a/lib/brval/val.rb
+++ b/lib/brval/val.rb
@@ -10,7 +10,7 @@ module Brval
 
     def mask
       return if @code.nil?
-      code_mask = @code.dup
+      masked
     end
 
     def valid?

--- a/spec/lib/brval_spec.rb
+++ b/spec/lib/brval_spec.rb
@@ -18,7 +18,15 @@ RSpec.describe Brval do
         expect(valid).to be(false)
       end
 
-      # Add a test with mask
+      it 'should return true .cpf_mask' do
+        masked = Brval.cpf_mask(cpf_valid)
+        expect(masked).to eql(cpf_valid.insert(3, '.').insert(7, '.').insert(11, '-'))
+      end
+
+      it 'should return false .cpf_mask' do
+        masked = Brval.cpf_mask(cpf_valid)
+        expect(masked).not_to eql(cpf_valid)
+      end
     end
 
     context 'CNPJ values' do
@@ -31,7 +39,16 @@ RSpec.describe Brval do
         valid = Brval.cnpj_valid?(cnpj_invalid)
         expect(valid).to be(false)
       end
-      # Add a test with mask
+
+      it 'should return true .cnpj_mask' do
+        masked = Brval.cnpj_mask(cnpj_valid)
+        expect(masked).to eql(cnpj_valid.insert(2, '.').insert(6, '.').insert(10, '/').insert(15, '-'))
+      end
+
+      it 'should return false .cnpj_mask' do
+        masked = Brval.cnpj_mask(cnpj_valid)
+        expect(masked).not_to eql(cnpj_valid)
+      end
     end
 
     context 'Pis values' do


### PR DESCRIPTION
Para manter a consistência de retorno do `valid?`, que é apenas `boolean`, adicionei uma validação para sempre retornar false se o valor do `code` for `nil`.